### PR TITLE
Adds landmarks model

### DIFF
--- a/client/src/models/landmark.js
+++ b/client/src/models/landmark.js
@@ -1,0 +1,18 @@
+const PubSub = require('../helpers/pub_sub');
+const Request = require('../helpers/request');
+
+const Landmark = function(url) {
+  this.url = url;
+}
+
+Landmark.prototype.getData = function() {
+  const request = new Request(this.url);
+  request
+    .get()
+    .then(data => {
+      PubSub.publish("Landmarks:data-loaded", data);
+    })
+    .catch(console.error);
+}
+
+module.exports = Landmark;


### PR DESCRIPTION
The model only has a getData() function at the moment. The constructor requires the URL of the API to be passed when it's called in app.js.